### PR TITLE
Use built-in constants instead of integers for boolexpr

### DIFF
--- a/tex/latex/csvsimple/csvsimple-l3.sty
+++ b/tex/latex/csvsimple/csvsimple-l3.sty
@@ -33,7 +33,7 @@
     \msg_warning:nn { csvsimple }{ l3 / package-loaded }
     \tex_endinput:D
   }
-\bool_const:Nn \c__csvsim_package_expl_bool { 1 }
+\bool_const:Nn \c__csvsim_package_expl_bool { \c_true_bool }
 
 
 

--- a/tex/latex/csvsimple/csvsimple-legacy.sty
+++ b/tex/latex/csvsimple/csvsimple-legacy.sty
@@ -32,7 +32,7 @@
     \msg_warning:nn { csvsimple }{ legacy / package-loaded }
     \tex_endinput:D
   }
-\bool_const:Nn \c__csvsim_package_expl_bool { 0 }
+\bool_const:Nn \c__csvsim_package_expl_bool { \c_false_bool }
 \ExplSyntaxOff
 
 


### PR DESCRIPTION
I compiled the following `csvsimple_test.tex` with TeX Live 2022 (tlmgr revision 63068) and got the error below.
```csvsimple_test.tex
\documentclass{article}
\usepackage[l3]{csvsimple}
\title{csvsimple-l3 test}
\begin{document}
\end{document}
```
```
This is LuaHBTeX, Version 1.15.0 (TeX Live 2022) 
 restricted system commands enabled.
(./csvsimple_test.tex
LaTeX2e <2022-06-01> patch level 1
 L3 programming layer <2022-06-16>
(/usr/local/texlive/2022/texmf-dist/tex/latex/base/article.cls
Document Class: article 2021/10/04 v1.4n Standard LaTeX document class
(/usr/local/texlive/2022/texmf-dist/tex/latex/base/size10.clo))
(/usr/local/texlive/2022/texmf-dist/tex/latex/csvsimple/csvsimple.sty
(/usr/local/texlive/2022/texmf-dist/tex/latex/l3packages/l3keys2e/l3keys2e.sty
(/usr/local/texlive/2022/texmf-dist/tex/latex/l3kernel/expl3.sty
(/usr/local/texlive/2022/texmf-dist/tex/latex/l3backend/l3backend-luatex.def)))
) (/usr/local/texlive/2022/texmf-dist/tex/latex/csvsimple/csvsimple-l3.sty
! Missing number, treated as zero.
<to be read again> 
\relax 
l.36 ..._const:Nn \c__csvsim_package_expl_bool { 1 }
                                                  
? 

! LaTeX Error: Missing \begin{document}.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.36 ..._const:Nn \c__csvsim_package_expl_bool { 1 }
                                                  
? 
) (./csvsimple_test.aux)
(/usr/local/texlive/2022/texmf-dist/tex/latex/base/ts1cmr.fd) [1
Missing character: There is no ^^A (U+0001) in font [lmroman10-regular]:+tlig;!

{/usr/local/texlive/2022/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
(./csvsimple_test.aux))
 406 words of node memory still in use:
   3 hlist, 1 vlist, 1 rule, 2 glue, 3 kern, 1 glyph, 4 attribute, 48 glue_spec
, 4 attribute_list, 1 write nodes
   avail lists: 2:29,3:4,4:1,5:22,6:2,7:44,9:18
</usr/local/texlive/2021/texmf-dist/fonts/opentype/public/lm/lmroman10-regular.
otf>
Output written on csvsimple_test.pdf (1 page, 2872 bytes).
Transcript written on csvsimple_test.log.
```
I referred to the [`expl3`'s documentation](https://texdoc.org/serve/interface3/0) and found that there are built-in constants `\c_true_bool` and `\c_false_bool`. Replacing them enabled me to compile the source without any problem.