### PR TITLE
docs: add `after first line` to the list of collected keys

### DIFF
--- a/doc/latex/csvsimple/CHANGES.md
+++ b/doc/latex/csvsimple/CHANGES.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 ### Changed
+- In `collect data` documentation, add `after first line` to list of collected keys (issue #28)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/doc/latex/csvsimple/csvsimple-l3.tex
+++ b/doc/latex/csvsimple/csvsimple-l3.tex
@@ -2241,6 +2241,7 @@ from the CSV file plus user additions into a macro named \refCom{csvdatacollecti
 Setting \refKey{/csvsim/collect data} adds the contents of the following keys
 to \refCom{csvdatacollection}:
 \begin{itemize}
+\item\refKey{/csvsim/after first line}
 \item\refKey{/csvsim/after head}
 \item\refKey{/csvsim/after line}
 \item\refKey{/csvsim/before first line}


### PR DESCRIPTION
Commit 3cb41f7 (2.5.0, 2023-10-16) solved the code part of #28, and this PR adds the missing documentation part.

The new key is inserted assuming the whole list is currently in lexicographic order.

Feel free to adjust the wording and classification of changelog entry before merging. With "Allow edits by maintainers" checked (by myself, the PR author), users with write access to this repo can add new commits to my `docs/collect-data` branch. You can use `git fetch origin pull/<pr-id>/head:<local-branch-name>` to checkout _my_ fork's `docs/collect-data` locally, and modify and push it as normal. (`gh pr checkout <pr-id>` may fail on a shallow clone, see https://github.com/cli/cli/issues/4287.)

Related GitHub Docs articles
- "[Checking out pull requests locally][checkout-pr-branch]"
- "[Committing changes to a pull request branch created from a fork][commit-to-pr-branch]".

[checkout-pr-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally
[commit-to-pr-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/committing-changes-to-a-pull-request-branch-created-from-a-fork