### PR TITLE
correct doc typo introduced in v2.6.0

### DIFF
--- a/doc/latex/csvsimple/csvsimple-l3.tex
+++ b/doc/latex/csvsimple/csvsimple-l3.tex
@@ -2432,7 +2432,7 @@ for backward compatibility.
 
 
 \begin{docCommands}[
-      doc parameter = \marg{floating point expression}\marg{token list B}\marg{true}\marg{false}
+      doc parameter = \marg{floating point expression}\marg{true}\marg{false}
     ]
   {
     { doc name = IfCsvsimFpCompareTF, doc new and updated = {2021-06-28}{2023-12-19} },
@@ -2446,7 +2446,7 @@ for backward compatibility.
 
 
 \begin{docCommands}[
-      doc parameter = \marg{integer expression}\marg{token list B}\marg{true}\marg{false}
+      doc parameter = \marg{integer expression}\marg{true}\marg{false}
     ]
   {
     { doc name = IfCsvsimIntCompareTF, doc new and updated = {2021-06-28}{2023-12-19} },


### PR DESCRIPTION
In version 2.6.0 the argument specification `\marg{token list B}` was added to `IfCsvsimFpCompareTF`, `ifcsvfpcmp`, `IfCsvsimIntCompareTF`, and `ifcsvintcmp`. This PR just removes it.